### PR TITLE
feat(dependency-injection): add dependency-injection code without the metadata

### DIFF
--- a/compiler/index.ts
+++ b/compiler/index.ts
@@ -9,7 +9,7 @@ import { ViewCompiler } from './view-compiler';
 import { ViewModelCompiler, ResourceModule } from './view-model-compiler';
 import { AureliaModuleCompiler } from './module-compiler';
 import 'aurelia-polyfills';
-import { Container } from 'aurelia-dependency-injection';
+import { Container } from '../src/framework/dependency-injection/container';
 import { TemplatingBindingLanguage } from './binding-language';
 import { SyntaxInterpreter } from './syntax-interpreter';
 

--- a/src/framework/dependency-injection/container.ts
+++ b/src/framework/dependency-injection/container.ts
@@ -1,0 +1,419 @@
+import { StrategyResolver } from './resolvers';
+import { InvocationHandler } from './invocation-handler';
+import { IContainerConfiguration, IResolver } from './interfaces';
+
+export const _emptyParameters = Object.freeze([]);
+
+/**
+ * A lightweight, extensible dependency injection container.
+ */
+export class Container {
+  /**
+   * The global root Container instance. Available if makeGlobal() has been called. Aurelia Framework calls makeGlobal().
+   */
+  static instance: Container;
+
+  /**
+   * The parent container in the DI hierarchy.
+   */
+  public parent: Container;
+
+  /**
+   * The root container in the DI hierarchy.
+   */
+  public root: Container;
+
+  /** @internal */
+  protected _configuration: IContainerConfiguration;
+
+  /** @internal */
+  protected _onHandlerCreated: (handler: InvocationHandler) => InvocationHandler;
+
+  /** @internal */
+  protected _handlers: Map<any, any>;
+
+  /** @internal */
+  protected _resolvers: Map<any, any>;
+
+  /**
+   * Creates an instance of Container.
+   * @param configuration Provides some configuration for the new Container instance.
+   */
+  constructor(configuration?: IContainerConfiguration) {
+    if (configuration === undefined) {
+      configuration = {};
+    }
+
+    this._configuration = configuration;
+    this._onHandlerCreated = configuration.onHandlerCreated;
+    this._handlers = configuration.handlers || (configuration.handlers = new Map());
+    this._resolvers = new Map();
+    this.root = this;
+    this.parent = null;
+  }
+
+  /**
+   * Makes this container instance globally reachable through Container.instance.
+   */
+  public makeGlobal(): Container {
+    Container.instance = this;
+    return this;
+  }
+
+  /**
+   * Sets an invocation handler creation callback that will be called when new InvocationsHandlers are created (called once per Function).
+   * @param onHandlerCreated The callback to be called when an InvocationsHandler is created.
+   */
+  public setHandlerCreatedCallback(onHandlerCreated: (handler: InvocationHandler) => InvocationHandler): void {
+    this._onHandlerCreated = onHandlerCreated;
+    this._configuration.onHandlerCreated = onHandlerCreated;
+  }
+
+  /**
+   * Registers an existing object instance with the container.
+   * @param key The key that identifies the dependency at resolution time; usually a constructor function.
+   * @param instance The instance that will be resolved when the key is matched. This defaults to the key value when instance is not supplied.
+   * @return The resolver that was registered.
+   */
+  public registerInstance(key: any, instance?: any): IResolver {
+    return this.registerResolver(key, new StrategyResolver(0, instance === undefined ? key : instance));
+  }
+
+  /**
+   * Registers a type (constructor function) such that the container always returns the same instance for each request.
+   * @param key The key that identifies the dependency at resolution time; usually a constructor function.
+   * @param fn The constructor function to use when the dependency needs to be instantiated. This defaults to the key value when fn is not supplied.
+   * @return The resolver that was registered.
+   */
+  public registerSingleton(key: any, fn?: Function): IResolver {
+    return this.registerResolver(key, new StrategyResolver(1, fn === undefined ? key : fn));
+  }
+
+  /**
+   * Registers a type (constructor function) such that the container returns a new instance for each request.
+   * @param key The key that identifies the dependency at resolution time; usually a constructor function.
+   * @param fn The constructor function to use when the dependency needs to be instantiated. This defaults to the key value when fn is not supplied.
+   * @return The resolver that was registered.
+   */
+  public registerTransient(key: any, fn?: Function): IResolver {
+    return this.registerResolver(key, new StrategyResolver(2, fn === undefined ? key : fn));
+  }
+
+  /**
+   * Registers a custom resolution function such that the container calls this function for each request to obtain the instance.
+   * @param key The key that identifies the dependency at resolution time; usually a constructor function.
+   * @param handler The resolution function to use when the dependency is needed.
+   * @return The resolver that was registered.
+   */
+  public registerHandler(
+    key: any,
+    handler: (container?: Container, key?: any, resolver?: IResolver) => any
+  ): IResolver {
+    return this.registerResolver(key, new StrategyResolver(3, handler));
+  }
+
+  /**
+   * Registers an additional key that serves as an alias to the original DI key.
+   * @param originalKey The key that originally identified the dependency; usually a constructor function.
+   * @param aliasKey An alternate key which can also be used to resolve the same dependency  as the original.
+   * @return The resolver that was registered.
+   */
+  public registerAlias(originalKey: any, aliasKey: any): IResolver {
+    return this.registerResolver(aliasKey, new StrategyResolver(5, originalKey));
+  }
+
+  /**
+   * Registers a custom resolution function such that the container calls this function for each request to obtain the instance.
+   * @param key The key that identifies the dependency at resolution time; usually a constructor function.
+   * @param resolver The resolver to use when the dependency is needed.
+   * @return The resolver that was registered.
+   */
+  public registerResolver(key: any, resolver: IResolver): IResolver {
+    validateKey(key);
+
+    let allResolvers = this._resolvers;
+    let result = allResolvers.get(key);
+
+    if (result === undefined) {
+      allResolvers.set(key, resolver);
+    } else if (result.strategy === 4) {
+      result.state.push(resolver);
+    } else {
+      allResolvers.set(key, new StrategyResolver(4, [result, resolver]));
+    }
+
+    return resolver;
+  }
+
+  /**
+   * Registers a type (constructor function) by inspecting its registration annotations. If none are found, then the default singleton registration is used.
+   * @param key The key that identifies the dependency at resolution time; usually a constructor function.
+   * @param fn The constructor function to use when the dependency needs to be instantiated. This defaults to the key value when fn is not supplied.
+   */
+  public autoRegister(key: any, fn?: Function): IResolver {
+    fn = fn === undefined ? key : fn;
+
+    if (typeof fn === 'function') {
+      return this.registerResolver(key, new StrategyResolver(1, fn));
+    }
+
+    return this.registerResolver(key, new StrategyResolver(0, fn));
+  }
+
+  /**
+   * Registers an array of types (constructor functions) by inspecting their registration annotations. If none are found, then the default singleton registration is used.
+   * @param fns The constructor function to use when the dependency needs to be instantiated.
+   */
+  public autoRegisterAll(fns: any[]): void {
+    let i = fns.length;
+    while (i--) {
+      this.autoRegister(fns[i]);
+    }
+  }
+
+  /**
+   * Unregisters based on key.
+   * @param key The key that identifies the dependency at resolution time; usually a constructor function.
+   */
+  public unregister(key: any): void {
+    this._resolvers.delete(key);
+  }
+
+  /**
+   * Inspects the container to determine if a particular key has been registred.
+   * @param key The key that identifies the dependency at resolution time; usually a constructor function.
+   * @param checkParent Indicates whether or not to check the parent container hierarchy.
+   * @return Returns true if the key has been registred; false otherwise.
+   */
+  public hasResolver(key: any, checkParent: boolean = false): boolean {
+    validateKey(key);
+
+    return (
+      this._resolvers.has(key) || (checkParent && this.parent !== null && this.parent.hasResolver(key, checkParent))
+    );
+  }
+
+  /**
+   * Gets the resolver for the particular key, if it has been registered.
+   * @param key The key that identifies the dependency at resolution time; usually a constructor function.
+   * @return Returns the resolver, if registred, otherwise undefined.
+   */
+  public getResolver(key: any): any {
+    return this._resolvers.get(key);
+  }
+
+  /**
+   * Resolves a single instance based on the provided key.
+   * @param key The key that identifies the object to resolve.
+   * @return Returns the resolved instance.
+   */
+  public get(key: any): any {
+    validateKey(key);
+
+    if (key === Container) {
+      return this;
+    }
+
+    let resolver = this._resolvers.get(key);
+
+    if (resolver === undefined) {
+      if (this.parent === null) {
+        return this.autoRegister(key).get(this, key);
+      }
+
+      return this.parent._get(key);
+    }
+
+    return resolver.get(this, key);
+  }
+
+  protected _get(key) {
+    let resolver = this._resolvers.get(key);
+
+    if (resolver === undefined) {
+      if (this.parent === null) {
+        return this.autoRegister(key).get(this, key);
+      }
+
+      return this.parent._get(key);
+    }
+
+    return resolver.get(this, key);
+  }
+
+  /**
+   * Resolves all instance registered under the provided key.
+   * @param key The key that identifies the objects to resolve.
+   * @return Returns an array of the resolved instances.
+   */
+  public getAll(key: any): ReadonlyArray<any> {
+    validateKey(key);
+
+    let resolver = this._resolvers.get(key);
+
+    if (resolver === undefined) {
+      if (this.parent === null) {
+        return _emptyParameters;
+      }
+
+      return this.parent.getAll(key);
+    }
+
+    if (resolver.strategy === 4) {
+      let state = resolver.state;
+      let i = state.length;
+      let results = new Array(i);
+
+      while (i--) {
+        results[i] = state[i].get(this, key);
+      }
+
+      return results;
+    }
+
+    return [resolver.get(this, key)];
+  }
+
+  /**
+   * Creates a new dependency injection container whose parent is the current container.
+   * @return Returns a new container instance parented to this.
+   */
+  public createChild(): Container {
+    let child = new Container(this._configuration);
+    child.root = this.root;
+    child.parent = this;
+    return child;
+  }
+
+  /**
+   * Invokes a function, recursively resolving its dependencies.
+   * @param fn The function to invoke with the auto-resolved dependencies.
+   * @param dynamicDependencies Additional function dependencies to use during invocation.
+   * @return Returns the instance resulting from calling the function.
+   */
+  public invoke(fn: Function & { name?: string }, dynamicDependencies?: any[]): any {
+    try {
+      let handler = this._handlers.get(fn);
+
+      if (handler === undefined) {
+        handler = this._createInvocationHandler(fn);
+        this._handlers.set(fn, handler);
+      }
+
+      return handler.invoke(this, dynamicDependencies);
+    } catch (e) {
+      throw new Error(`Error invoking ${fn.name}.`);
+    }
+  }
+
+  protected _createInvocationHandler(fn: Function & { inject?: any }): InvocationHandler {
+    let dependencies;
+
+    dependencies = [];
+    let ctor = fn;
+    while (typeof ctor === 'function') {
+      dependencies.push(...getDependencies(ctor));
+      ctor = Object.getPrototypeOf(ctor);
+    }
+
+    let invoker = classInvokers[dependencies.length] || classInvokers.fallback;
+
+    let handler = new InvocationHandler(fn, invoker, dependencies);
+    return this._onHandlerCreated !== undefined ? this._onHandlerCreated(handler) : handler;
+  }
+}
+
+function invokeWithDynamicDependencies(container, fn, staticDependencies, dynamicDependencies) {
+  let i = staticDependencies.length;
+  let args = new Array(i);
+  let lookup;
+
+  while (i--) {
+    lookup = staticDependencies[i];
+
+    if (lookup === null || lookup === undefined) {
+      throw new Error(
+        'Constructor Parameter with index ' +
+          i +
+          " cannot be null or undefined. Are you trying to inject/register something that doesn't exist with DI?"
+      );
+    } else {
+      args[i] = container.get(lookup);
+    }
+  }
+
+  if (dynamicDependencies !== undefined) {
+    args = args.concat(dynamicDependencies);
+  }
+
+  return Reflect.construct(fn, args);
+}
+
+let classInvokers = {
+  [0]: {
+    invoke(container, Type) {
+      return new Type();
+    },
+    invokeWithDynamicDependencies: invokeWithDynamicDependencies
+  },
+  [1]: {
+    invoke(container, Type, deps) {
+      return new Type(container.get(deps[0]));
+    },
+    invokeWithDynamicDependencies: invokeWithDynamicDependencies
+  },
+  [2]: {
+    invoke(container, Type, deps) {
+      return new Type(container.get(deps[0]), container.get(deps[1]));
+    },
+    invokeWithDynamicDependencies: invokeWithDynamicDependencies
+  },
+  [3]: {
+    invoke(container, Type, deps) {
+      return new Type(container.get(deps[0]), container.get(deps[1]), container.get(deps[2]));
+    },
+    invokeWithDynamicDependencies: invokeWithDynamicDependencies
+  },
+  [4]: {
+    invoke(container, Type, deps) {
+      return new Type(container.get(deps[0]), container.get(deps[1]), container.get(deps[2]), container.get(deps[3]));
+    },
+    invokeWithDynamicDependencies: invokeWithDynamicDependencies
+  },
+  [5]: {
+    invoke(container, Type, deps) {
+      return new Type(
+        container.get(deps[0]),
+        container.get(deps[1]),
+        container.get(deps[2]),
+        container.get(deps[3]),
+        container.get(deps[4])
+      );
+    },
+    invokeWithDynamicDependencies: invokeWithDynamicDependencies
+  },
+  fallback: {
+    invoke: invokeWithDynamicDependencies,
+    invokeWithDynamicDependencies: invokeWithDynamicDependencies
+  }
+};
+
+function getDependencies(f) {
+  if (!f.hasOwnProperty('inject')) {
+    return [];
+  }
+
+  if (typeof f.inject === 'function') {
+    return f.inject();
+  }
+
+  return f.inject;
+}
+
+function validateKey(key: any) {
+  if (key === null || key === undefined) {
+    throw new Error(
+      "key/value cannot be null or undefined. Are you trying to inject/register something that doesn't exist with DI?"
+    );
+  }
+}

--- a/src/framework/dependency-injection/interfaces.ts
+++ b/src/framework/dependency-injection/interfaces.ts
@@ -1,0 +1,54 @@
+import { InvocationHandler } from './invocation-handler';
+import { Container } from './container';
+
+/**
+ * A strategy for invoking a function, resulting in an object instance.
+ */
+export interface IInvoker {
+  /**
+   * Invokes the function with the provided dependencies.
+   * @param fn The constructor or factory function.
+   * @param dependencies The dependencies of the function call.
+   * @return The result of the function invocation.
+   */
+  invoke(container: Container, fn: Function, dependencies: any[]): any;
+
+  /**
+   * Invokes the function with the provided dependencies.
+   * @param fn The constructor or factory function.
+   * @param staticDependencies The static dependencies of the function.
+   * @param dynamicDependencies Additional dependencies to use during invocation.
+   * @return The result of the function invocation.
+   */
+  invokeWithDynamicDependencies(
+    container: Container,
+    fn: Function,
+    staticDependencies: any[],
+    dynamicDependencies: any[]
+  ): any;
+}
+
+/**
+ * Used to allow functions/classes to specify custom dependency resolution logic.
+ */
+export interface IResolver {
+  /**
+   * Called by the container to allow custom resolution of dependencies for a function/class.
+   * @param container The container to resolve from.
+   * @param key The key that the resolver was registered as.
+   * @return Returns the resolved object.
+   */
+  get(container: Container, key: any): any;
+}
+
+/**
+ * Used to configure a Container instance.
+ */
+export interface IContainerConfiguration {
+  /**
+   * An optional callback which will be called when any function needs an InvocationHandler created (called once per Function).
+   */
+  onHandlerCreated?: (handler: InvocationHandler) => InvocationHandler;
+
+  handlers?: Map<any, any>;
+}

--- a/src/framework/dependency-injection/invocation-handler.ts
+++ b/src/framework/dependency-injection/invocation-handler.ts
@@ -1,0 +1,46 @@
+import { Container } from './container';
+import { IInvoker } from './interfaces';
+
+/**
+ * Stores the information needed to invoke a function.
+ */
+export class InvocationHandler {
+  /**
+   * The function to be invoked by this handler.
+   */
+  fn: Function;
+
+  /**
+   * The invoker implementation that will be used to actually invoke the function.
+   */
+  invoker: IInvoker;
+
+  /**
+   * The statically known dependencies of this function invocation.
+   */
+  dependencies: any[];
+
+  /**
+   * Instantiates an InvocationDescription.
+   * @param fn The Function described by this description object.
+   * @param invoker The strategy for invoking the function.
+   * @param dependencies The static dependencies of the function call.
+   */
+  constructor(fn: Function, invoker: IInvoker, dependencies: any[]) {
+    this.fn = fn;
+    this.invoker = invoker;
+    this.dependencies = dependencies;
+  }
+
+  /**
+   * Invokes the function.
+   * @param container The calling container.
+   * @param dynamicDependencies Additional dependencies to use during invocation.
+   * @return The result of the function invocation.
+   */
+  invoke(container: Container, dynamicDependencies?: any[]): any {
+    return dynamicDependencies !== undefined
+      ? this.invoker.invokeWithDynamicDependencies(container, this.fn, this.dependencies, dynamicDependencies)
+      : this.invoker.invoke(container, this.fn, this.dependencies);
+  }
+}

--- a/src/framework/dependency-injection/resolvers.ts
+++ b/src/framework/dependency-injection/resolvers.ts
@@ -1,0 +1,44 @@
+import { Container } from './container';
+
+export class StrategyResolver {
+  public strategy: StrategyResolver | number;
+  public state: any;
+
+  /**
+   * Creates an instance of the StrategyResolver class.
+   * @param strategy The type of resolution strategy.
+   * @param state The state associated with the resolution strategy.
+   */
+  constructor(strategy: StrategyResolver | number, state: any) {
+    this.strategy = strategy;
+    this.state = state;
+  }
+
+  /**
+   * Called by the container to allow custom resolution of dependencies for a function/class.
+   * @param container The container to resolve from.
+   * @param key The key that the resolver was registered as.
+   * @return Returns the resolved object.
+   */
+  public get(container: Container, key: any): any {
+    switch (this.strategy) {
+      case 0: //instance
+        return this.state;
+      case 1: //singleton
+        let singleton = container.invoke(this.state);
+        this.state = singleton;
+        this.strategy = 0;
+        return singleton;
+      case 2: //transient
+        return container.invoke(this.state);
+      case 3: //function
+        return this.state(container, key, this);
+      case 4: //array
+        return this.state[0].get(container, key);
+      case 5: //alias
+        return container.get(this.state);
+      default:
+        throw new Error('Invalid strategy: ' + this.strategy);
+    }
+  }
+}

--- a/test/unit/framework/dependency-injection/container.spec.ts
+++ b/test/unit/framework/dependency-injection/container.spec.ts
@@ -1,0 +1,327 @@
+import { Container } from '../../../../src/framework/dependency-injection/container';
+
+
+describe('container', () => {
+  describe('injection', () => {
+    it('instantiates class without injected services', function() {
+      class App {}
+
+      let container = new Container();
+      let app = container.get(App);
+
+      expect(app).toEqual(jasmine.any(App));
+    });
+
+    it('uses static inject method (ES6)', function() {
+      class Logger {}
+
+      class App {
+        logger;
+        static inject() {
+          return [Logger];
+        }
+        constructor(logger) {
+          this.logger = logger;
+        }
+      }
+
+      let container = new Container();
+      let app = container.get(App);
+      expect(app.logger).toEqual(jasmine.any(Logger));
+    });
+
+    it('uses static inject property (TypeScript,CoffeeScript,ES5)', function() {
+      class Logger {}
+
+      class App {
+        static inject;
+        logger;
+        constructor(logger) {
+          this.logger = logger;
+        }
+      }
+
+      App.inject = [Logger];
+
+      let container = new Container();
+      let app = container.get(App);
+
+      expect(app.logger).toEqual(jasmine.any(Logger));
+    });
+  });
+
+  describe('inheritence', function() {
+    class Logger {}
+    class Service {}
+
+    it('loads dependencies for the parent class', function() {
+      class ParentApp {
+        static inject() {
+          return [Logger];
+        }
+        logger;
+        constructor(logger) {
+          this.logger = logger;
+        }
+      }
+
+      class ChildApp extends ParentApp {
+        constructor(dep) {
+          super(dep);
+        }
+      }
+
+      let container = new Container();
+      let app = container.get(ChildApp);
+      expect(app.logger).toEqual(jasmine.any(Logger));
+    });
+
+    it('loads dependencies for the child class', function() {
+      class ParentApp {}
+
+      class ChildApp extends ParentApp {
+        static inject() {
+          return [Service];
+        }
+        service;
+        constructor(service, ...rest) {
+          super();
+          this.service = service;
+        }
+      }
+
+      let container = new Container();
+      let app = container.get(ChildApp);
+      expect(app.service).toEqual(jasmine.any(Service));
+    });
+
+    it('loads dependencies for both classes', function() {
+      class ParentApp {
+        static inject() {
+          return [Logger];
+        }
+        logger;
+        constructor(logger) {
+          this.logger = logger;
+        }
+      }
+
+      class ChildApp extends ParentApp {
+        static inject() {
+          return [Service];
+        }
+        service;
+        constructor(service, dep) {
+          super(dep);
+          this.service = service;
+        }
+      }
+
+      let container = new Container();
+      let app = container.get(ChildApp);
+      expect(app.service).toEqual(jasmine.any(Service));
+      expect(app.logger).toEqual(jasmine.any(Logger));
+    });
+  });
+
+  describe('registration', () => {
+    it('asserts keys are defined', () => {
+      let container = new Container();
+
+      expect(() => container.get(null)).toThrow();
+      expect(() => container.get(undefined)).toThrow();
+
+      expect(() => container.registerInstance(null, {})).toThrow();
+      expect(() => container.registerInstance(undefined, {})).toThrow();
+
+      expect(() => container.registerSingleton(null)).toThrow();
+      expect(() => container.registerSingleton(undefined)).toThrow();
+
+      expect(() => container.registerTransient(null)).toThrow();
+      expect(() => container.registerTransient(undefined)).toThrow();
+
+      expect(() => container.autoRegister(null)).toThrow();
+      expect(() => container.autoRegister(undefined)).toThrow();
+
+      expect(() => container.autoRegisterAll([null])).toThrow();
+      expect(() => container.autoRegisterAll([undefined])).toThrow();
+
+      expect(() => container.registerHandler(null, undefined)).toThrow();
+      expect(() => container.registerHandler(undefined, undefined)).toThrow();
+
+      expect(() => (container as any).hasHandler(null)).toThrow();
+      expect(() => (container as any).hasHandler(undefined)).toThrow();
+    });
+
+    it('configures transient (non singleton) via api', () => {
+      class Logger {}
+
+      class App1 {
+        static inject() {
+          return [Logger];
+        }
+        logger;
+        constructor(logger) {
+          this.logger = logger;
+        }
+      }
+
+      class App2 {
+        static inject() {
+          return [Logger];
+        }
+        logger;
+        constructor(logger) {
+          this.logger = logger;
+        }
+      }
+
+      let container = new Container();
+      container.registerTransient(Logger, Logger);
+
+      let app1 = container.get(App1);
+      let app2 = container.get(App2);
+
+      expect(app1.logger).not.toBe(app2.logger);
+    });
+
+    it('configures instance via api', () => {
+      class Logger {}
+
+      class App1 {
+        logger;
+        static inject() {
+          return [Logger];
+        }
+        constructor(logger) {
+          this.logger = logger;
+        }
+      }
+
+      class App2 {
+        logger;
+        static inject() {
+          return [Logger];
+        }
+        constructor(logger) {
+          this.logger = logger;
+        }
+      }
+
+      let container = new Container();
+      let instance = new Logger();
+      container.registerInstance(Logger, instance);
+
+      let app1 = container.get(App1);
+      let app2 = container.get(App2);
+
+      expect(app1.logger).toBe(instance);
+      expect(app2.logger).toBe(instance);
+    });
+
+    it('configures custom via api', () => {
+      class Logger {}
+
+      class App1 {
+        logger;
+        static inject() {
+          return [Logger];
+        }
+        constructor(logger) {
+          this.logger = logger;
+        }
+      }
+
+      class App2 {
+        logger;
+        static inject() {
+          return [Logger];
+        }
+        constructor(logger) {
+          this.logger = logger;
+        }
+      }
+
+      let container = new Container();
+      container.registerHandler(Logger, c => 'something strange');
+
+      let app1 = container.get(App1);
+      let app2 = container.get(App2);
+
+      expect(app1.logger).toEqual('something strange');
+      expect(app2.logger).toEqual('something strange');
+    });
+
+    it('configures key as service when transient api only provided with key', () => {
+      class Logger {}
+
+      let container = new Container();
+      container.registerTransient(Logger);
+
+      let logger1 = container.get(Logger);
+      let logger2 = container.get(Logger);
+
+      expect(logger1).toEqual(jasmine.any(Logger));
+      expect(logger2).toEqual(jasmine.any(Logger));
+      expect(logger2).not.toBe(logger1);
+    });
+
+    it('configures key as service when singleton api only provided with key', () => {
+      class Logger {}
+
+      let container = new Container();
+      container.registerSingleton(Logger);
+
+      let logger1 = container.get(Logger);
+      let logger2 = container.get(Logger);
+
+      expect(logger1).toEqual(jasmine.any(Logger));
+      expect(logger2).toEqual(jasmine.any(Logger));
+      expect(logger2).toBe(logger1);
+    });
+
+    it('configures concrete singleton via api for abstract dependency', () => {
+      class LoggerBase {}
+      class Logger extends LoggerBase {}
+
+      class App {
+        logger;
+        static inject() {
+          return [LoggerBase];
+        }
+        constructor(logger) {
+          this.logger = logger;
+        }
+      }
+
+      let container = new Container();
+      container.registerSingleton(LoggerBase, Logger);
+
+      let app = container.get(App);
+
+      expect(app.logger).toEqual(jasmine.any(Logger));
+    });
+
+    it('configures concrete transient via api for abstract dependency', () => {
+      class LoggerBase {}
+      class Logger extends LoggerBase {}
+
+      class App {
+        logger;
+        static inject() {
+          return [LoggerBase];
+        }
+        constructor(logger) {
+          this.logger = logger;
+        }
+      }
+
+      let container = new Container();
+      container.registerTransient(LoggerBase, Logger);
+
+      let app = container.get(App);
+
+      expect(app.logger).toEqual(jasmine.any(Logger));
+    });
+  });
+});


### PR DESCRIPTION
From the `aurelia-depdendency-injection` source, with decorators and metadata-dependent code removed. Doesn't break existing usage from what I can see.