### PR TITLE
perf(test-dbmonster): disable debug config

### DIFF
--- a/src/test-dbmonster/startup.ts
+++ b/src/test-dbmonster/startup.ts
@@ -4,6 +4,6 @@ import { GeneratedConfiguration } from './generated-configuration';
 import { DebugConfiguration } from '../debug/configuration';
 
 window['au'] = new Aurelia()
-  .register(GeneratedConfiguration, DebugConfiguration)
+  .register(GeneratedConfiguration)
   .app({ host: document.querySelector('app'), component: new App() })
   .start();


### PR DESCRIPTION
Quite a big difference. `prepareStack` was eating ~50% of the cpu (well, now we know..)