### PR TITLE
refactor(binding): remove connect-queue (temporarily)

### DIFF
--- a/src/runtime/binding/binding.ts
+++ b/src/runtime/binding/binding.ts
@@ -6,66 +6,6 @@ import { IServiceLocator } from '../../kernel/di';
 import { IScope, sourceContext, targetContext } from './binding-context';
 import { Reporter } from '../../kernel/reporter';
 import { BindingFlags } from './binding-flags';
-import { PLATFORM } from '../../kernel/platform';
-
-const queue: Binding[] = new Array();       // the connect queue
-const queued: {[id: number]: boolean} = {}; // tracks whether a binding with a particular id is in the queue
-let nextId: number = 0;                     // next available id that can be assigned to a binding for queue tracking purposes
-const minimumImmediate: number = 100;       // number of bindings we should connect immediately before resorting to queueing
-const frameBudget: number = 15;             // milliseconds allotted to each frame for flushing queue
-
-let isFlushRequested = false;               // whether a flush of the connect queue has been requested
-let immediate = 0;                          // count of bindings that have been immediately connected
-
-function flush(animationFrameStart: number) {
-  const length = queue.length;
-  let i = 0;
-  
-  while (i < length) {
-    const binding = queue[i];
-    queued[binding.__connectQueueId] = false;
-    binding.connect(true);
-    i++;
-    // periodically check whether the frame budget has been hit.
-    // this ensures we don't call performance.now a lot and prevents starving the connect queue.
-    if (i % 100 === 0 && PLATFORM.now() - animationFrameStart > frameBudget) {
-      break;
-    }
-  }
-
-  queue.splice(0, i);
-
-  if (queue.length) {
-    PLATFORM.requestAnimationFrame(flush);
-  } else {
-    isFlushRequested = false;
-    immediate = 0;
-  }
-}
-
-function enqueueBindingConnect(binding) {
-  if (immediate < minimumImmediate) {
-    immediate++;
-    binding.connect(false);
-  } else {
-    // get or assign the binding's id that enables tracking whether it's been queued.
-    let id = binding.__connectQueueId;
-    if (id === undefined) {
-      id = nextId;
-      nextId++;
-      binding.__connectQueueId = id;
-    }
-    // enqueue the binding.
-    if (!queued[id]) {
-      queue.push(binding);
-      queued[id] = true;
-    }
-  }
-  if (!isFlushRequested) {
-    isFlushRequested = true;
-    PLATFORM.requestAnimationFrame(flush);
-  }
-}
 
 const slotNames: string[] = new Array(100);
 const versionSlotNames: string[] = new Array(100);
@@ -79,6 +19,8 @@ export interface IBinding extends IBindScope {
   locator: IServiceLocator;
   observeProperty(context: any, name: string): void;
 }
+
+// TODO: add connect-queue (or something similar) back in when everything else is working, to improve startup time
 
 export type IBindingTarget = any; // Node | CSSStyleDeclaration | IObservable;
 
@@ -175,7 +117,7 @@ export class Binding implements IBinding {
     if (mode === BindingMode.oneTime) {
       return;
     } else if (mode === BindingMode.toView) {
-      enqueueBindingConnect(this);
+      this.sourceExpression.connect(this, scope, BindingFlags.none);
     } else if (mode === BindingMode.twoWay) {
       this.sourceExpression.connect(this, scope, BindingFlags.none);
       (this.targetObserver as IBindingTargetObserver).subscribe(targetContext, this);


### PR DESCRIPTION
Removing this until all the binding logic is working properly and stabilized, to simplify the process. Then we can add it back in in a form that makes sense for the new logic.