### PR TITLE
chore(ci): enable npm ci verbose logging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
             node --version
             npm --version
       - checkout
-      - run: npm ci
+      - run: npm ci -dd
       - save_cache:
           paths:
             - node_modules


### PR DESCRIPTION
Hopefully make it easier to see what goes wrong when it goes wrong